### PR TITLE
scipy imread uint8

### DIFF
--- a/knn_matting.py
+++ b/knn_matting.py
@@ -8,7 +8,7 @@ nn = 10
 
 def knn_matte(img, trimap, mylambda=100):
     [m, n, c] = img.shape
-    img, trimap = img/255, trimap/255
+    img, trimap = img/255.0, trimap/255.0
     foreground = (trimap > 0.99).astype(int)
     background = (trimap < 0.01).astype(int)
     all_constraints = foreground + background


### PR DESCRIPTION
Python 2.7.12 
scipy 0.17.0
The Data type of images loaded by scipy.misc.imread('xxx.png') is "uint8", which causes problems.